### PR TITLE
Github Actions에 빌드 테스트 추가

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,29 @@
+name: Build test
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+
+      - name: Install Packages
+        run: yarn install
+
+      - name: Nextjs Build Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx', '**.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Build Test
+        run: yarn build


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #50 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
PR 올릴 시 빌드 테스트 되도록

버셀이 자동으로 해주는데 추가한 이유: 1) 현재 팀 권한을 못 받았는데 배포한 사람이 밤까지 컴퓨터를 볼 수 없는 상황임 그런데 그 전에 개발할 것이 너무 많아 테스트 결과를 보면서 해야 좋을 것 같아서 2) 어차피 나중에 개인 레포로 포크해서 재배포 할 것이라

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
X

## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->
X

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
https://github.com/sopt-makers/sopt-playground-frontend/blob/main/.github/workflows/build-test.yml
참고했습니다

~~일단 머지해서 잘 되는지 확인해보아야 할 것 같습니당~~
오 바로 되네요!