### PR TITLE
feat: 메인 페이지 카드 목록 api 연동

### DIFF
--- a/components/home/CategoryCard.tsx
+++ b/components/home/CategoryCard.tsx
@@ -1,5 +1,12 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 import { COLORS } from 'styles/colors';
+
+interface Props {
+  id: string;
+  name: string;
+  posts: [];
+}
 
 const CardContainer = styled.div`
   width: 224px;
@@ -23,16 +30,21 @@ const CardContainer = styled.div`
 `;
 
 const CategoryTitle = styled.div`
+  width: 75%;
+  padding: 6px 0;
+  text-align: center;
   font-weight: 700;
   font-size: 35px;
   font-family: 'UhBee EUN KYUNG';
-  text-decoration: underline;
+  border-bottom: 2px solid;
   color: #2b2b2b;
 `;
 
 const CategorySub = styled.div`
   font-weight: 400;
   font-size: 18px;
+  text-decoration: none;
+  color: #000000;
 `;
 
 const CountCircle = styled.div`
@@ -54,12 +66,35 @@ const CountCircle = styled.div`
   }
 `;
 
-export default function CategoryCard() {
+export default function CategoryCard({ id, name, posts }: Props) {
+  const nextUrl = `/post/${id}`;
+
+  const gettranslateName = (name: string) => {
+    switch (name) {
+      case 'study':
+        return '공부';
+      case 'develop':
+        return '개발';
+      case 'job':
+        return '취업';
+      case 'reading':
+        return '독서';
+      case 'hobby':
+        return '취미';
+      case 'etc':
+        return '기타';
+      default:
+        return '카테고리';
+    }
+  };
+
   return (
-    <CardContainer>
-      <CategoryTitle>카테고리</CategoryTitle>
-      <CategorySub>뽀모방 개수</CategorySub>
-      <CountCircle>4</CountCircle>
-    </CardContainer>
+    <Link href={nextUrl} style={{ textDecoration: 'none' }}>
+      <CardContainer>
+        <CategoryTitle>{gettranslateName(name)}</CategoryTitle>
+        <CategorySub>뽀모방 개수</CategorySub>
+        <CountCircle>{posts.length}</CountCircle>
+      </CardContainer>
+    </Link>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,8 @@ import SearchIcon from '@public/icons/search.svg';
 import styled from '@emotion/styled';
 import { COLORS } from './../styles/colors';
 import UserCard from '@components/home/UserCard';
+import { useEffect, useState } from 'react';
+import { axiosInstance } from 'api';
 
 const MainContainer = styled.main`
   background-color: white;
@@ -99,6 +101,23 @@ const UserList = styled.ul`
 `;
 
 export default function Home() {
+  const [categoryArr, setCategoryArr] = useState([]);
+
+  const getCategoryArr = async () => {
+    try {
+      const res = await axiosInstance.get('/channels');
+      if (res.status === 200) {
+        setCategoryArr(res.data);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    getCategoryArr();
+  }, []);
+
   return (
     <MainContainer>
       <CategoryContainer>
@@ -108,12 +127,9 @@ export default function Home() {
         </MainTextDiv>
         <SubTextDiv>원하시는 카테고리를 선택해주세요.</SubTextDiv>
         <CategoryCardList>
-          <CategoryCard />
-          <CategoryCard />
-          <CategoryCard />
-          <CategoryCard />
-          <CategoryCard />
-          <CategoryCard />
+          {categoryArr.map(({ _id, name, posts }) => (
+            <CategoryCard key={_id} id={_id} name={name} posts={posts} />
+          ))}
         </CategoryCardList>
       </CategoryContainer>
       <UserListContainer>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #47 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

- /channel 에서 데이터를 받아와 렌더링, 
- 각 카테고리 카드별 클릭시 /post/[categoryId] 로 이동 
- 카테고리 이름은 영어 -> 한글로 변경


## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

![image](https://user-images.githubusercontent.com/67576476/212529346-c93bb28a-7926-4d65-b797-8abd1a751f7e.png)


## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->

axios를 이용하여 데이터 get 요청 받아와서 각 카드별로 _id, name, posts 를 넘겨줌
카테고리 카드는 가져온 데이터를 바탕으로 렌더링(name은 한글로 번역)

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

X