### PR TITLE
feat: next api 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ yarn-error.log*
 # local env files
 .env*.local
 
+.env
+
 # vercel
 .vercel
 

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,20 +1,39 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 
-export const axiosInstance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+const setInterceptor = (instance: AxiosInstance) => {
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.code === 'ECONNABORTED' || error.response?.status === 408) {
+        alert('요청이 만료되었습니다.');
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  return instance;
+};
+
+const options = {
   headers: {
     Accept: '*/*',
     'Content-Type': 'application/json',
   },
   timeout: 500,
-});
+};
 
-axiosInstance.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.code === 'ECONNABORTED' || error.response?.status === 408) {
-      alert('요청이 만료되었습니다.');
-    }
-    return Promise.reject(error);
-  },
+export const internalApi = setInterceptor(
+  axios.create({
+    ...options,
+  }),
 );
+
+export const publicApi = setInterceptor(
+  axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    ...options,
+  }),
+);
+
+// 기존 instance
+export { internalApi as axiosInstance };

--- a/pages/api/channels.ts
+++ b/pages/api/channels.ts
@@ -1,0 +1,14 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosResponse } from 'axios';
+
+import { publicApi } from 'api';
+
+export default async function login(_request: NextApiRequest, response: NextApiResponse) {
+  try {
+    const { data }: AxiosResponse = await publicApi.get('/channels');
+
+    return response.status(200).end(JSON.stringify(data));
+  } catch (err) {
+    return response.status(500).end(JSON.stringify(err));
+  }
+}

--- a/pages/api/channels.ts
+++ b/pages/api/channels.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from 'axios';
 
 import { publicApi } from 'api';
 
-export default async function login(_request: NextApiRequest, response: NextApiResponse) {
+export default async function channels(_request: NextApiRequest, response: NextApiResponse) {
   try {
     const { data }: AxiosResponse = await publicApi.get('/channels');
 

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosResponse } from 'axios';
+
+import { publicApi } from 'api';
+
+export default async function login(request: NextApiRequest, response: NextApiResponse) {
+  const { body } = request;
+
+  try {
+    const { data }: AxiosResponse = await publicApi.post('/login', body);
+
+    return response.status(200).end(JSON.stringify(data));
+  } catch (err) {
+    return response.status(500).end(JSON.stringify(err));
+  }
+}

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -3,7 +3,7 @@ import { AxiosResponse } from 'axios';
 
 import { publicApi } from 'api';
 
-export default async function login(request: NextApiRequest, response: NextApiResponse) {
+export default async function signup(request: NextApiRequest, response: NextApiResponse) {
   const { body } = request;
 
   try {

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -1,0 +1,16 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { AxiosResponse } from 'axios';
+
+import { publicApi } from 'api';
+
+export default async function login(request: NextApiRequest, response: NextApiResponse) {
+  const { body } = request;
+
+  try {
+    const { data }: AxiosResponse = await publicApi.post('/signup', body);
+
+    return response.status(200).end(JSON.stringify(data));
+  } catch (err) {
+    return response.status(500).end(JSON.stringify(err));
+  }
+}


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #78 

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
`/api/channels`로 요청보낸 경우
<img width="1395" alt="스크린샷 2023-01-15 오후 9 42 57" src="https://user-images.githubusercontent.com/57716832/212541251-5c7c0d79-7fe8-4870-bca5-26b922bccb64.png">

## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->
구현 완료된 api
- [x] /api/login
- [x] /api/signup
- [x] /api/channels

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- `api/index.ts` 변경사항
  - 내부적으로 사용하는 axios 인스턴스와 public 인스턴스를 구분하여 사용할 수 있도록 수정했습니다.
- 혹시 merge 기다리고 있는 pr들과 conflict 날까봐 아직 api url을 수정하지는 않았습니다!
- api 연결 중이시라면 경로 앞에 `/api/` 붙여주세요!
  - ex) `/login` -> `/api/login`
- http 관련 이슈가 해결되는지 먼저 확인해보고 싶어서 pr 먼저 생성했습니다!
- 다들 확인 한번 해주시라고 reviewer로 설정했습니다. 😀