### PR TITLE
fix: production에서의 next api 동적 라우팅 404 에러 fix

### DIFF
--- a/components/post/hooks/queries.ts
+++ b/components/post/hooks/queries.ts
@@ -7,7 +7,7 @@ export const useGetPost = (id: string) =>
   useQuery<AxiosResponse<Post, unknown>, unknown, Post, string[]>(
     ['post_getPost', id],
     async () => {
-      const { data } = await axiosInstance.get(`/api/posts/${id}`);
+      const { data } = await axiosInstance.post(`/api/posts`, id);
       return data;
     },
     { enabled: !!id },

--- a/pages/api/post.ts
+++ b/pages/api/post.ts
@@ -6,9 +6,7 @@ import { isCategoryNameInDB } from '@components/post/types';
 import { CATEGORY_NAME_MAP } from '@components/post/constants';
 
 export default async function getPost(request: NextApiRequest, response: NextApiResponse) {
-  const {
-    query: { postId },
-  } = request;
+  const { body: postId } = request;
 
   try {
     const { data }: AxiosResponse = await publicApi.get(`/posts/${postId}`);


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #93

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
프로덕션에서 next api로 동적 라우팅 시 발생하는 404 에러 해결

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->

## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->
이것저것 시도해보았는데(https://github.com/prgrms-fe-devcourse/FEDC3_POMO_DY/pull/108) 정확한 원인을 찾지 못했습니다,,
그래서 @zerosial 님이 authUser에서 하셨던 것처럼
next 서버에는 정적 루트(api/post)로 post 요청으로 body에 id를 담아 보내고,
next 서버가 그 id로 실서버에 get 요청을 해서 결국 동적 라우트를 사용하지 않는 방안을 택했습니다

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
열심히 했는데 api url을 https로 수정해주셔서 의미가 없어졌네요 ㅎ.ㅎ ..
이대로도 동작할테니까 일단 머지하겠습니다 ~
나중에 한번에 걷어낼 부분 걷어내요!