### PR TITLE
feat: 뽀모 모집글 상세 모달 구현

### DIFF
--- a/components/postDetails/UserList.tsx
+++ b/components/postDetails/UserList.tsx
@@ -1,19 +1,20 @@
 import styled from '@emotion/styled';
 
-import DefaultProfile from 'public/images/profile.svg';
 import { UserInfo } from './types';
 
 interface Props {
   users: Array<UserInfo>;
 }
-
+``;
 function UserList({ users }: Props) {
+  const DefaultProfile = '/images/profile.svg';
+
   return (
     <Container>
-      {users.map(({ userName }, idx) => {
+      {users.map(({ userName, image }, idx) => {
         return (
           <UserItem key={idx}>
-            <ProfileImage />
+            <ProfileImage src={image ?? DefaultProfile} />
             <UserName>{userName}</UserName>
           </UserItem>
         );
@@ -33,12 +34,15 @@ const UserItem = styled.li`
   display: flex;
   align-items: center;
   gap: 12px;
+  margin-bottom: 5px;
 `;
 
-const ProfileImage = styled(DefaultProfile)`
-  min-width: 30px;
-  max-width: 30px;
-`;
+const ProfileImage = styled.img((prop) => {
+  return {
+    minWidth: '25px',
+    maxWidth: '25px',
+  };
+});
 
 const UserName = styled.span`
   display: block;

--- a/components/postDetails/UserList.tsx
+++ b/components/postDetails/UserList.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+import DefaultProfile from 'public/images/profile.svg';
+import { UserInfo } from './types';
+
+interface Props {
+  users: Array<UserInfo>;
+}
+
+function UserList({ users }: Props) {
+  return (
+    <Container>
+      {users.map(({ userName }, idx) => {
+        return (
+          <UserItem key={idx}>
+            <ProfileImage />
+            <UserName>{userName}</UserName>
+          </UserItem>
+        );
+      })}
+    </Container>
+  );
+}
+
+const Container = styled.ul`
+  list-style: none;
+  padding: 0;
+  max-height: 90px;
+  overflow: scroll;
+`;
+
+const UserItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const ProfileImage = styled(DefaultProfile)`
+  min-width: 30px;
+  max-width: 30px;
+`;
+
+const UserName = styled.span`
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellips;
+  font-size: 1.1rem;
+`;
+
+export default UserList;

--- a/components/postDetails/fetchUsers.ts
+++ b/components/postDetails/fetchUsers.ts
@@ -1,0 +1,17 @@
+import { AxiosResponse } from 'axios';
+
+import { publicApi } from 'api';
+import { UserInfo } from './types';
+
+export const fetchUsers = async (users: Array<{ id: string; userId: string }>) => {
+  const userData: Array<UserInfo> = [];
+
+  for (const { userId } of users) {
+    const {
+      data: { image, fullName: userName },
+    }: AxiosResponse = await publicApi.get(`/users/${userId}`);
+    userData.push({ image: image ?? null, userId, userName });
+  }
+
+  return userData;
+};

--- a/components/postDetails/index.tsx
+++ b/components/postDetails/index.tsx
@@ -1,0 +1,185 @@
+import { MouseEventHandler, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
+
+import Modal from '@components/common/modal';
+import UserList from './UserList';
+import { UserInfo } from './types';
+import { COLORS } from 'styles/colors';
+import { publicApi } from 'api';
+import { fetchUsers } from './fetchUsers';
+
+interface PostInfo {
+  _id: string;
+  channelId: string;
+  title: string;
+  description: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  iteration: string;
+  likes: Array<{ id: string; userId: string }>;
+}
+
+interface Props {
+  postInfo: PostInfo;
+  isOpen: boolean;
+  setIsOpen: (value: boolean) => void;
+}
+
+function PostDetails({ postInfo, isOpen, setIsOpen }: Props) {
+  const router = useRouter();
+  const {
+    _id: postId,
+    channelId,
+    title,
+    description: content,
+    date,
+    startTime,
+    endTime,
+    iteration: interval,
+    likes: participants,
+  } = postInfo;
+  const dummyUserData = [
+    { id: '63c806ddd10a060b921e3efa', userId: '63c2b8272358f16faf4df0c5' },
+    { id: '63c806ddd10a060b921e3efa', userId: '63c2b8272358f16faf4df0c5' },
+    { id: '63c806ddd10a060b921e3efa', userId: '63c2b8272358f16faf4df0c5' },
+    { id: '63c806ddd10a060b921e3efa', userId: '63c2b8272358f16faf4df0c5' },
+  ];
+  const [users, setUsers] = useState<UserInfo[]>([]);
+
+  const getUsersInfo = async () => {
+    const userInfo = await fetchUsers(dummyUserData);
+    // const userInfo = await fetchUsers(participants);
+    setUsers([...userInfo]);
+  };
+
+  useEffect(() => {
+    getUsersInfo();
+  }, []);
+
+  const handleEnterPost: MouseEventHandler = (e: React.MouseEvent<HTMLButtonElement>) => {
+    console.log(e);
+
+    publicApi
+      .post('/likes/create', { postId })
+      .then((res) => {
+        console.log(res);
+        router.push(`/post/${channelId}/${postId}`);
+      })
+      .catch(() => alert('뽀모에 참가할 수 없어요 ㅠ.ㅠ'));
+  };
+
+  return (
+    <Modal isModalOpen={isOpen} setIsModalOpen={setIsOpen}>
+      <Container>
+        <PostInfoWrapper>
+          <PostTitle>{title}</PostTitle>
+          <PostContent>{content}</PostContent>
+          <FlexWrapper>
+            <PostTimeInfo>
+              <p>
+                <SubTitle>일자</SubTitle>
+                <SubDescription>{date}</SubDescription>
+              </p>
+              <p>
+                <SubTitle>시간</SubTitle>
+                <SubDescription>
+                  <Highlight>{startTime}</Highlight> - {endTime}
+                </SubDescription>
+              </p>
+              <p>
+                <SubTitle>반복</SubTitle>
+                <SubDescription>
+                  <Highlight>{interval}회</Highlight>
+                </SubDescription>
+              </p>
+            </PostTimeInfo>
+            <PostParticipants>
+              <SubTitle>참여 멤버</SubTitle>
+              <UserList users={users} />
+            </PostParticipants>
+          </FlexWrapper>
+        </PostInfoWrapper>
+        <EnterButton onClick={handleEnterPost}>뽀모 참여하기</EnterButton>
+      </Container>
+    </Modal>
+  );
+}
+
+const Container = styled.div`
+  min-width: 400px;
+  max-width: 450px;
+  min-height: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: scroll;
+`;
+
+const PostInfoWrapper = styled.div`
+  padding: 0 13% 20px;
+`;
+
+const PostTitle = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+`;
+
+const PostContent = styled.p`
+  max-height: 200px;
+  margin-bottom: 50px;
+  font-size: 1.1rem;
+  line-height: 1.4;
+  overflow: scroll;
+`;
+
+const FlexWrapper = styled.div`
+  display: flex;
+`;
+
+const PostTimeInfo = styled.div`
+  width: 65%;
+  min-height: 150px;
+  & > p {
+    margin: 0 0 10px 0;
+  }
+`;
+
+const PostParticipants = styled.div`
+  width: 35%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const SubTitle = styled.span`
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #838383;
+  margin-right: 7%;
+`;
+
+const SubDescription = styled.span`
+  font-size: 1.1rem;
+  font-weight: 600;
+`;
+
+const EnterButton = styled.button({
+  minWidth: '150px',
+  minHeight: '43px',
+  marginBottom: '30px',
+  backgroundColor: COLORS.main,
+  fontSize: '1.1rem',
+  fontWeight: '500',
+  color: 'white',
+  border: 'none',
+  padding: '5px 30px',
+  borderRadius: '28px',
+  alignSelf: 'center',
+  cursor: 'pointer',
+});
+
+const Highlight = styled.span`
+  color: ${COLORS.main};
+`;
+
+export default PostDetails;

--- a/components/postDetails/types.ts
+++ b/components/postDetails/types.ts
@@ -1,0 +1,5 @@
+export interface UserInfo {
+  userId: string;
+  userName: string;
+  image: string | null;
+}

--- a/pages/modal/index.tsx
+++ b/pages/modal/index.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+import PostDetails from '@components/postDetails';
+
+// FIXME: 뽀모 모집글 상세 모달을 사용하는 템플릿 페이지입니다. 추후 삭제할 예정입니다!
+function ModalPage() {
+  const [isModalOpen, setIsModalOpen] = useState(true);
+  const dummyPostInfo = {
+    _id: '63c5b7adaab6f72d8708ec52',
+    channelId: '63c22e612358f16faf4df033',
+    title: '같이 모각코해요',
+    description:
+      '4시간 모여서 각자 코딩해요~ 할일이 너무너무 많은데... 엉엉엉 울고싶다다다당... 같이 화이팅해요오옹....',
+    date: '2022.01.19',
+    startTime: '10:00',
+    endTime: '11:00',
+    iteration: '3',
+    likes: [{ id: 'likeId', userId: 'userId' }],
+  };
+
+  return (
+    <>
+      <button onClick={() => setIsModalOpen(!isModalOpen)}>뽀모 모집글 보기</button>
+      <PostDetails postInfo={dummyPostInfo} isOpen={isModalOpen} setIsOpen={setIsModalOpen} />
+    </>
+  );
+}
+
+export default ModalPage;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #77 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- 뽀모 모집글 상세 모달 구현
<img width="375" alt="스크린샷 2023-01-19 오후 3 28 29" src="https://user-images.githubusercontent.com/57716832/213371282-0c894634-13f6-4a6a-ba74-b27a9f810324.png">

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
https://user-images.githubusercontent.com/57716832/213370471-0ecd21d8-e369-4a4f-bde8-2775ccfcf763.mov


## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->
- [x] 뽀모 모집글 상세 모달 PostDetails 컴포넌트 구현
- [x] fix: image null 이면 default image 보이게
```ts
interface PostInfo {
  _id: string;
  channelId: string;
  title: string;
  description: string;
  date: string;
  startTime: string;
  endTime: string;
  iteration: string;
  likes: Array<{ id: string; userId: string }>; // 참여자 목록
}

interface PostDetailsProps {
  postInfo: PostInfo;
  isOpen: boolean;
  setIsOpen: (value: boolean) => void;
}
```
- `postInfo.likes`에는 사용자 이름과 프로필 이미지가 담겨오지 않기 때문에 참여자 목록을 보여주기 위해 `/users/:userId`로 get 요청을 보냅니다.

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 모달의 동작을 보여주기 위해 임의의 ModalPage를 만들었습니다. 뽀모 글 목록 페이지 내부에 모달 연결 후 삭제하겠습니다!