### PR TITLE
feat: 네비게이션 바 페이지 이동 구현 & 네비게이션 바 노출 제한

### DIFF
--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -4,6 +4,7 @@ import LogoSmall from '@public/images/logo-small.svg';
 import { SearchBox, SearchResult } from '@components/common/Search';
 import { css } from '@emotion/react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { axiosInstance } from 'api';
 import { isCategoryNameInDB } from '@components/post/types';
 import { CATEGORY_NAME_MAP } from '@components/post/constants';
@@ -25,11 +26,18 @@ const LogoContainer = styled.div`
   align-items: center;
   margin-left: 16px;
   margin-right: auto;
+
+  & > a {
+    display: flex;
+    text-decoration: none;
+    align-items: center;
+  }
 `;
 const LogoTitle = styled.div`
   font-family: 'UhBee EUN KYUNG';
   font-size: 1.5rem;
   font-weight: 700;
+  color: #000000;
 `;
 
 const User = styled.div`
@@ -157,14 +165,18 @@ export const Header: FunctionComponent = () => {
   return (
     <Bar>
       <LogoContainer>
-        <LogoSmall style={{ marginRight: '16px' }} />
-        <LogoTitle> 뽀모 </LogoTitle>
+        <Link href="/">
+          <LogoSmall style={{ marginRight: '16px' }} />
+          <LogoTitle> 뽀모 </LogoTitle>
+        </Link>
       </LogoContainer>
       <SearchBox onChange={onChangeHandler} isOpen={isOpen}>
         <SearchResult results={searchResults} />
       </SearchBox>
       <User>
-        <Profile src="/images/profile.svg" alt="프로필이미지" />
+        <Link href="/profile">
+          <Profile src="/images/profile.svg" alt="프로필이미지" />
+        </Link>
         <Notification src="/images/notification.svg" alt="알람이미지" />
       </User>
     </Bar>

--- a/components/layout/BaseLayout.tsx
+++ b/components/layout/BaseLayout.tsx
@@ -1,0 +1,19 @@
+import { Header } from '@components/common/Header';
+import { ReactNode, useMemo } from 'react';
+import { useRouter } from 'next/router';
+
+export default function BaseLayout(props: { children: ReactNode }) {
+  const router = useRouter();
+
+  const isNotAccessable = useMemo(
+    () => router.pathname.startsWith('/login') || router.pathname.startsWith('/sign'),
+    [router.pathname],
+  );
+
+  return (
+    <>
+      {!isNotAccessable && <Header />}
+      {props.children}
+    </>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,7 @@ import { global } from '../styles/global';
 import '../public/fonts/index.css';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { Header } from '@components/common/Header';
+import BaseLayout from '@components/layout/BaseLayout';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { refetchOnWindowFocus: false, refetchOnReconnect: false, retry: 1 } },
@@ -20,8 +20,9 @@ export default function App({ Component, pageProps }: AppProps) {
           <title>뽀모 - 같이 뽀모해요!</title>
         </Head>
         <Global styles={global} />
-        <Header />
-        <Component {...pageProps} />
+        <BaseLayout>
+          <Component {...pageProps} />
+        </BaseLayout>
       </QueryClientProvider>
     </>
   );


### PR DESCRIPTION
## 📌 이슈번호
- close #86 #67 

## 👩‍💻 요구 사항
- 네비게이션 메뉴 버튼 클릭 시 페이지 이동(홈, 프로필)
- 네비게이션 바(헤더) 로그인 페이지, 회원가입 페이지 제한

## 🎨 구현 스크린샷 
기능이 간단한 관계로 생략

## 📝 구현 내용 
- 페이지 이동은 기본적으로 Link 를 활용했습니다.
- 네비게이션 바 노출 제한의 경우에는 BaseLayout을 만들어서 사용했습니다.


## ✅ PR 포인트 