### PR TITLE
fix: 종료된 pomo는 모달 뜨지 않도록 수정

### DIFF
--- a/components/posts/PostCard.tsx
+++ b/components/posts/PostCard.tsx
@@ -38,16 +38,17 @@ export default function PostCard({ _id, participants, data, createdAt, onPostCli
   const { channelId, title, date, content: description, startTime, endTime, interval: iteration } = data;
 
   const [isInProgress, setIsInProgress] = useState(false);
+  const isPomoEnd = isEnd(`${date} ${endTime}`);
 
   const onClick: MouseEventHandler = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!isInProgress) {
+    if (!isInProgress && !isPomoEnd) {
       onPostClick({ _id, channelId, title, date, description, startTime, endTime, iteration, likes: participants });
     }
   };
 
   useEffect(() => {
     setIsInProgress(getIsInProgress(date, startTime, endTime));
-  }, [startTime, endTime]);
+  }, [date, startTime, endTime]);
 
   return (
     <CardContainer onClick={onClick}>
@@ -57,7 +58,7 @@ export default function PostCard({ _id, participants, data, createdAt, onPostCli
           <CoverMsg>진행 중인 뽀모예요</CoverMsg>
         </CardCoverContainer>
       )}
-      {isEnd(`${date} ${endTime}`) && (
+      {isPomoEnd && (
         <EndCardCoverContainer>
           <SadTomatoSvg />
           <CoverMsg>종료된 뽀모예요</CoverMsg>


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #150 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
- [x] 종료된 뽀모는 모달 뜨지 않도록 수정

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
https://user-images.githubusercontent.com/57716832/214803221-801c24af-1957-4643-83cd-1d01b1d0ac93.mov


## 📝 구현 내용 <!-- 어떻게 구현했는지 작성해 주세요 -->
- 은아님이 작성하신 `isEnd` util 함수 활용해서, 종료된 뽀모는 이벤트 함수가 실행되지 않도록 구현했습니다.

## ✅ PR 포인트  <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
x